### PR TITLE
Issue #21

### DIFF
--- a/app.py
+++ b/app.py
@@ -60,7 +60,7 @@ def index():
             subx_threshold_mode = request.form.get('subx-threshold', 'auto')
             subx_override = request.form.get('subx-override', 'none')
             day_end_hour = int(request.form.get('day-end-hour', 'none'))
-            trim_percentage = int(request.form.get('trim-percentage', 'none'))
+            trim_percentage = request.form.get('trim-percentage', 5, type=int)
             timezone = request.form.get('tz', 'UTC')
 
             if secondary_y_axis == 'none':

--- a/app.py
+++ b/app.py
@@ -60,6 +60,7 @@ def index():
             subx_threshold_mode = request.form.get('subx-threshold', 'auto')
             subx_override = request.form.get('subx-override', 'none')
             day_end_hour = int(request.form.get('day-end-hour', 'none'))
+            trim_percentage = int(request.form.get('trim-percentage', 'none'))
             timezone = request.form.get('tz', 'UTC')
 
             if secondary_y_axis == 'none':
@@ -69,7 +70,7 @@ def index():
             try:
                 solves_details, overall_pbs, solves_by_dates, timer_type, datalen = \
                     process_data(file_to_send, chart_by, secondary_y_axis, subx_threshold_mode, subx_override,
-                                 day_end_hour, timezone)
+                                 day_end_hour, timezone, trim_percentage)
                 return render_template("data.html", solves_details=solves_details, overall_pbs=overall_pbs,
                                        solves_by_dates=solves_by_dates, timer_type=timer_type, datalen=datalen)
             except NotImplementedError:

--- a/app.py
+++ b/app.py
@@ -59,7 +59,7 @@ def index():
             secondary_y_axis = request.form.get('secondary-y-axis', 'none')
             subx_threshold_mode = request.form.get('subx-threshold', 'auto')
             subx_override = request.form.get('subx-override', 'none')
-            day_end_hour = int(request.form.get('day-end-hour', 'none'))
+            day_end_hour = request.form.get('day-end-hour', 3, type=int)
             trim_percentage = request.form.get('trim-percentage', 5, type=int)
             timezone = request.form.get('tz', 'UTC')
 

--- a/backend.py
+++ b/backend.py
@@ -49,6 +49,9 @@ def rolling_trimmed_mean(data, window_size, outliers_to_trim):
     means = repeat(NaN, len(data))
     rsd = repeat(NaN, len(data))
 
+    if outliers_to_trim >= window_size - outliers_to_trim:
+        return means, rsd
+
     for i in range(window_size, len(data) + 1):
         if x[window_size - outliers_to_trim - 1]['IsDNF'] == 1:
             means[i - 1] = NaN
@@ -60,6 +63,9 @@ def rolling_trimmed_mean(data, window_size, outliers_to_trim):
             rsd_std = counting_solves.std()
             if rsd_std > 0:
                 rsd[i - 1] = round(rsd_std / counting_solves_mean, 3)
+            # case can happen with large trim resulting in single solve
+            elif rsd_std == 0:
+                rsd[i - 1] = 0
 
         if i != len(data):
             idx_old = binary_search_2d(x, data[i - window_size], window_size)
@@ -76,7 +82,7 @@ def rolling_trimmed_mean(data, window_size, outliers_to_trim):
     return means, rsd
 
 
-def calculate_and_store_running_ao(solves_data, puzzle, category, ao_len):
+def calculate_and_store_running_ao(solves_data, puzzle, category, ao_len, trim_percentage):
     solves_data_part = solves_data[(solves_data['Puzzle'] == puzzle) & (solves_data['Category'] == category)][[
         'TimeCentiSec', 'IsDNF']]
     solves_data_part_array = array(solves_data_part.to_records())
@@ -85,7 +91,7 @@ def calculate_and_store_running_ao(solves_data, puzzle, category, ao_len):
         outliers_to_trim = 0
         prefix = 'mo'
     else:
-        outliers_to_trim = ceil(ao_len * (5 / 100))
+        outliers_to_trim = ceil(ao_len * (trim_percentage / 100))
         prefix = 'ao'
 
     means, rsd = rolling_trimmed_mean(solves_data_part_array, ao_len, outliers_to_trim)
@@ -1193,12 +1199,16 @@ def drop_all_dnf_categories(solves_data):
     return solves_data[~solves_grouped_index.isin(all_dnf_index)]
 
 
-def process_data(file, chart_by, secondary_y_axis, subx_threshold_mode, subx_override, day_end_hour, timezone):
+def process_data(file, chart_by, secondary_y_axis, subx_threshold_mode, subx_override, day_end_hour, timezone, trim_percentage):
     set_option('display.max_colwidth', -1)
 
     # timezone could be a tz name string, or an offset in minutes
     if represents_int(timezone):
         timezone = int(timezone) * 60  # need it in seconds for tz_convert
+
+    # limit to 40 to keep at least one solve for ao5
+    if trim_percentage < 0 or trim_percentage > 40:
+        trim_percentage = 5
 
     solves_data, has_dates, timer_type = create_dataframe(file, timezone)
 
@@ -1217,7 +1227,7 @@ def process_data(file, chart_by, secondary_y_axis, subx_threshold_mode, subx_ove
     subx_thresholds = dict()
     for idx, puzzle, category in solves_data[['Puzzle', 'Category']].drop_duplicates().itertuples():
         for ao_len in (3, 5, 12, 50, 100, 1000):
-            calculate_and_store_running_ao(solves_data, puzzle, category, ao_len)
+            calculate_and_store_running_ao(solves_data, puzzle, category, ao_len, trim_percentage)
         if secondary_y_axis == 'subx':
             if subx_threshold_mode == 'auto':
                 subx_threshold = get_subx_threshold(solves_data, puzzle, category)

--- a/backend.py
+++ b/backend.py
@@ -1138,7 +1138,7 @@ def create_dataframe(file, timezone):
         # WCA ID
         timer_type = 'WCAID'
 
-        with zipfile.ZipFile(os.path.join(WCA_DATA_FOLDER, 'WCA_export.tsv.zip')) as z:  # TODO folder deploy script
+        with zipfile.ZipFile(os.path.join(WCA_DATA_FOLDER, 'WCA_export.tsv.zip')) as z:
             filtered = BytesIO()
             with z.open('WCA_export_Results.tsv') as f:
                 for i, line in enumerate(f):
@@ -1171,8 +1171,9 @@ def create_dataframe(file, timezone):
                       value_vars=['value1', 'value2', 'value3', 'value4', 'value5'], var_name='result_id',
                       value_name='result').sort_values(
             ['SolveDatetime', 'name', 'resultRowId', 'result_id'])
+        melted = melted[(melted['result'] != 0) & (melted['result'] != -2)]  # 0=no result; -2=DNS
         melted['Penalty'] = 0
-        melted.loc[melted['result'] <= 0, 'Penalty'] = 2
+        melted.loc[melted['result'] <= 0, 'Penalty'] = 2  # -1=DNF, others?
         melted['Time(millis)'] = melted['result'] * 10
         melted.rename(inplace=True, columns={'name': 'Category'})
         melted['Puzzle'] = melted['personName'] + ' (' + melted['personId'] + ')'

--- a/templates/index.html
+++ b/templates/index.html
@@ -130,6 +130,51 @@
                                         </select>
                                     </div>
                                 </div>
+                                <div class="row align-items-baseline">
+                                    <div class="col p-2 text-left h6">Custom trimmed mean</div>
+                                    <div class="col p-2 btn-group btn-group-toggle" data-toggle="buttons"
+                                        id="custom-trimmed-mean-btns">
+                                        <label class="btn btn-light">
+                                            <input type="radio" name="custom-trimmed-mean" id="custom-trimmed-mean-yes"
+                                                value="yes" autocomplete="off"> Yes
+                                        </label>
+                                        <label class="btn btn-light active">
+                                            <input type="radio" name="custom-trimmed-mean" id="custom-trimmed-mean-no"
+                                                value="no" autocomplete="off" checked> No
+                                        </label>
+                                    </div>
+                                </div>
+                                <div class="row align-items-baseline" id="custom-trimmed-mean-section"
+                                    style="display: none;">
+                                    <div class="col p-2 text-left h6">Top/bottom trim</div>
+                                    <div class="col p-2">
+                                        <select class="custom-select" name="trim-percentage" id="trim-percentage-select">
+                                            <option value="0">0%</option>
+                                            <option value="5" selected>5% (default)</option>
+                                            <option value="10">10%</option>
+                                            <option value="15">15%</option>
+                                            <option value="20">20%</option>
+                                            <option value="25">25%</option>
+                                            <option value="30">30%</option>
+                                            <option value="35">35%</option>
+                                            <option value="40">40%</option>
+                                        </select>
+                                        <small>
+                                            <table class="table table-sm table-borderless table-striped">
+                                                <thead>
+                                                    <tr><th scope="col">Average</th><th scope="col">Counting solves</th></tr>
+                                                </thead>
+                                                <tbody>
+                                                    <tr><td>ao5</td><td id="ao5">3</td></tr>
+                                                    <tr><td>ao12</td><td id="ao12">10</td></tr>
+                                                    <tr><td>ao50</td><td id="ao50">44</td></tr>
+                                                    <tr><td>ao100</td><td id="ao100">90</td></tr>
+                                                    <tr><td>ao1000</td><td id="ao1000">900</td></tr>
+                                                </tbody>
+                                            </table>
+                                        </small>
+                                    </div>
+                                </div>
                             </div>
                         </div>
                     </div>
@@ -197,6 +242,33 @@ $('#subx-threshold-btns').click(function() {
     }, 200)
 });
 
+$('#custom-trimmed-mean-btns').click(function() {
+    setTimeout(function() {
+        if ($('#custom-trimmed-mean-yes').is(':checked')) {
+            $('#custom-trimmed-mean-section').fadeIn();
+        }
+        else {
+            $('#custom-trimmed-mean-section').fadeOut();
+        }
+    }, 200)
+});
+
+$('#trim-percentage-select').change(function() {
+    $('#trim-percentage-select option:selected').each(function() {
+        var selectedValue = parseInt($(this).val())
+        if (selectedValue >= 0 && selectedValue <= 40) {
+            $("#ao5").text(getCountingSolves(5, selectedValue))
+            $("#ao12").text(getCountingSolves(12, selectedValue))
+            $("#ao50").text(getCountingSolves(50, selectedValue))
+            $("#ao100").text(getCountingSolves(100, selectedValue))
+            $("#ao1000").text(getCountingSolves(1000, selectedValue))
+        }
+    });
+});
+
+function getCountingSolves(solvesNumber, trimPercentage) {
+    return solvesNumber - (Math.ceil(solvesNumber*trimPercentage/100)*2)
+}
 
 function shuffle(array) {
     var i = array.length,


### PR DESCRIPTION
Enhancement: Allows users to choose the percentage used for calculating
the trimmed mean.

https://github.com/tussosedan/kuebiko-cubing/issues/21

- Trimmed mean maximum percentage limited to 40% to avoid having ao5
with no counting solves.
- As expexted, 0% setting can lead to having missing averages if they
contain at least a DNF.
- A case was added to RSD computation to display 0% instead of NaN when
an average has a single counting solve.
- Javascript computation is only here to help the user understand the
impact of the setting. Actual computation is done serverside.